### PR TITLE
chore: Update pre-commit hooks and dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,76 @@
+default_language_version:
+  python: python3
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: no-commit-to-branch
+        args: ["--branch", "main", "--branch", "staging", "--branch", "dev"]
+      - id: mixed-line-ending
+      - id: end-of-file-fixer
+        exclude: '(\.sql|\.out|\.rs)$'
+      - id: trailing-whitespace
+        exclude: '(\.sql|\.out|\.rs)$'
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: check-docstring-first
+      - id: check-symlinks
+      - id: check-yaml
+      - id: check-json
+      - id: check-xml
+      - id: check-ast
+      - id: check-toml
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+        exclude: '\.rs$' # This doesn't play well with #![allow(clippy::crate_in_macro_def)]
+      - id: check-vcs-permalinks
+      - id: detect-private-key
+      - id: detect-aws-credentials
+        args: ["--allow-missing-credentials"]
+      - id: debug-statements
+      - id: destroyed-symlinks
+      - id: fix-encoding-pragma
+      - id: fix-byte-order-marker
+      - id: requirements-txt-fixer
+
+  - repo: https://github.com/lovesegfault/beautysh
+    rev: v6.2.1
+    hooks:
+      - id: beautysh
+        args: ["--indent-size", "2"]
+
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.9.0
+    hooks:
+      - id: shellcheck
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.37.0
+    hooks:
+      - id: markdownlint
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.3
+    hooks:
+      - id: prettier
+
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: fmt
+      - id: clippy
+      - id: cargo-check
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pylint-dev/pylint
+    rev: v3.0.1
+    hooks:
+      - id: pylint


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Copy `.pre-commit-config.yaml` from the paradedb https://github.com/paradedb/paradedb/blob/dev/.pre-commit-config.yaml, but remove the`mintlify-validate` because it seems that we do not maintain doc in the repo
## Why

## How

## Tests
