### PR TITLE
chore: Make `test-pg_analytics` run in CI

### DIFF
--- a/.github/workflows/test-pg_analytics.yml
+++ b/.github/workflows/test-pg_analytics.yml
@@ -13,9 +13,10 @@ on:
       - main
     paths:
       - ".github/workflows/test-pg_analytics.yml"
-      - "pg_analytics/**"
-      - "!pg_analytics/README.md"
-      - "shared/**"
+      - "src/**"
+      - "tests/**"
+      - "Cargo.toml"
+      - "pg_analytics.control"
   push:
     branches:
       - dev # Run CI on dev. This is important to fill the GitHub Actions cache in a way that pull requests can see it


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #60

## What
This was not properly configured since moving to the new repo, and the tests weren't running!

## Why
Run tests to avoid broken code

## How
Specify the paths properly

## Tests
See CI