### PR TITLE
ci: Re-Add benchmarking Tool

### DIFF
--- a/.github/workflows/benchmark-pg_analytics.yml
+++ b/.github/workflows/benchmark-pg_analytics.yml
@@ -1,0 +1,83 @@
+# workflows/benchmark-pg_analytics.yml
+#
+# Benchmark pg_analytics
+# Benchmark ParadeDB's pg_analytics performance against ClickBench.
+
+name: Benchmark pg_analytics
+
+on:
+  schedule:
+    - cron: "1 0 * * 1,2,3,4,5" # Run once per day on weekdays (days of the week 1-5) at 00:01 UTC
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - dev
+      - main
+    paths:
+      - ".github/workflows/benchmark-pg_analytics.yml"
+      - "src/**"
+      - "Cargo.toml"
+      - "pg_analytics.control"
+  workflow_dispatch:
+
+concurrency:
+  group: benchmark-pg_analytics-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark-pg_analytics:
+    name: Benchmark pg_analytics on ${{ matrix.name }}
+    runs-on: depot-ubuntu-latest-8
+    if: github.event.pull_request.draft == false
+    strategy:
+      matrix:
+        include:
+          - name: ClickBench (Parquet, single)
+            flags: -w single
+            pg_version: 16
+          - name: ClickBench (Parquet, partitioned)
+            flags: -w partitioned
+            pg_version: 16
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v4
+
+      # To access the cargo-paradedb benchmarking tool
+      - name: Checkout paradedb/paradedb Git Repository
+        run: git clone https://github.com/paradedb/paradedb
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install & Configure Supported PostgreSQL Version
+        run: |
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
+          sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/ /usr/lib/postgresql/${{ matrix.pg_version }}/ /var/lib/postgresql/${{ matrix.pg_version }}/
+          echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
+
+      - name: Install pgrx & pg_analytics
+        run: |
+          cargo install -j $(nproc) --locked cargo-pgrx --version 0.11.3
+          cargo pgrx init --pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
+          cargo pgrx install --pg-config="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config" --release
+
+      - name: Add pg_analytics to shared_preload_libraries
+        working-directory: /home/runner/.pgrx/data-${{ matrix.pg_version }}/
+        run: sed -i "s/^#shared_preload_libraries = .*/shared_preload_libraries = 'pg_analytics'/" postgresql.conf
+
+      - name: Install the ParadeDB Benchmarking Tool
+        working-directory: paradedb/cargo-paradedb/
+        run: cargo run install
+
+      - name: Run Official ${{ matrix.name }} Benchmark
+        run: |
+          cargo pgrx start pg${{ matrix.pg_version }}
+          cargo paradedb bench hits run ${{ matrix.flags }} --url postgresql://localhost:288${{ matrix.pg_version }}/postgres
+
+      - name: Notify Slack on Failure
+        if: failure() && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main')
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"text":"Benchmark pg_analytics on ${{ matrix.name }} workflow failed in `paradedb/paradedb` -- investigate immediately!"}' ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish-pg_analytics.yml
+++ b/.github/workflows/publish-pg_analytics.yml
@@ -164,13 +164,6 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v4
 
-      # We remove the existing pg_analytics/ directory, which just contains the README.md
-      - name: Clone paradedb/pg_analytics Repository & Add pg_analytics to Cargo.toml
-        run: |
-          rm -rf pg_analytics/
-          git clone https://github.com/paradedb/pg_analytics.git pg_analytics/
-          sed -i '/members = \[/,/\]/s/\]/    "pg_analytics",\n]/' Cargo.toml
-
       - name: Install Debian Dependencies
         if: ${{ matrix.image == 'debian:11-slim' || matrix.image == 'debian:12-slim' || matrix.image == 'ubuntu:22.04' || matrix.image == 'ubuntu:24.04' }}
         run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget curl gnupg lsb-release pkg-config libssl-dev jq


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #96

## What
This file had been omitted when migrating the projects. This solves that. I also fix a lingering issue in the publishing script deployment.

## Why
Finish the migration

## How
Re-added the file from the `paradedb/paradedb` repository, and made some edit to it to make it fit with the new repo.

## Tests
See CI