### PR TITLE
feat: Support generated/renamed columns in DuckDB

### DIFF
--- a/src/duckdb/csv.rs
+++ b/src/duckdb/csv.rs
@@ -79,6 +79,8 @@ pub enum CsvOption {
     Quote,
     #[strum(serialize = "sample_size")]
     SampleSize,
+    #[strum(serialize = "select")]
+    Select,
     #[strum(serialize = "sep")]
     Sep,
     #[strum(serialize = "skip")]
@@ -122,6 +124,7 @@ impl CsvOption {
             Self::PreserveCasing => false,
             Self::Quote => false,
             Self::SampleSize => false,
+            Self::Select => false,
             Self::Sep => false,
             Self::Skip => false,
             Self::Timestampformat => false,
@@ -305,7 +308,12 @@ pub fn create_view(
     .collect::<Vec<String>>()
     .join(", ");
 
-    Ok(format!("CREATE VIEW IF NOT EXISTS {schema_name}.{table_name} AS SELECT * FROM read_csv({create_csv_str})"))
+    let default_select = "*".to_string();
+    let select = table_options
+        .get(CsvOption::Select.as_ref())
+        .unwrap_or(&default_select);
+
+    Ok(format!("CREATE VIEW IF NOT EXISTS {schema_name}.{table_name} AS SELECT {select} FROM read_csv({create_csv_str})"))
 }
 
 #[cfg(test)]

--- a/src/duckdb/delta.rs
+++ b/src/duckdb/delta.rs
@@ -25,6 +25,8 @@ pub enum DeltaOption {
     Files,
     #[strum(serialize = "preserve_casing")]
     PreserveCasing,
+    #[strum(serialize = "select")]
+    Select,
 }
 
 impl DeltaOption {
@@ -32,6 +34,7 @@ impl DeltaOption {
         match self {
             Self::Files => true,
             Self::PreserveCasing => false,
+            Self::Select => false,
         }
     }
 }
@@ -48,8 +51,13 @@ pub fn create_view(
             .ok_or_else(|| anyhow!("files option is required"))?
     );
 
+    let default_select = "*".to_string();
+    let select = table_options
+        .get(DeltaOption::Select.as_ref())
+        .unwrap_or(&default_select);
+
     Ok(format!(
-        "CREATE VIEW IF NOT EXISTS {schema_name}.{table_name} AS SELECT * FROM delta_scan({files})"
+        "CREATE VIEW IF NOT EXISTS {schema_name}.{table_name} AS SELECT {select} FROM delta_scan({files})"
     ))
 }
 

--- a/src/duckdb/iceberg.rs
+++ b/src/duckdb/iceberg.rs
@@ -27,6 +27,8 @@ pub enum IcebergOption {
     Files,
     #[strum(serialize = "preserve_casing")]
     PreserveCasing,
+    #[strum(serialize = "select")]
+    Select,
 }
 
 impl IcebergOption {
@@ -35,6 +37,7 @@ impl IcebergOption {
             Self::AllowMovedPaths => false,
             Self::Files => true,
             Self::PreserveCasing => false,
+            Self::Select => false,
         }
     }
 }
@@ -61,7 +64,12 @@ pub fn create_view(
         .collect::<Vec<String>>()
         .join(", ");
 
-    Ok(format!("CREATE VIEW IF NOT EXISTS {schema_name}.{table_name} AS SELECT * FROM iceberg_scan({create_iceberg_str})"))
+    let default_select = "*".to_string();
+    let select = table_options
+        .get(IcebergOption::Select.as_ref())
+        .unwrap_or(&default_select);
+
+    Ok(format!("CREATE VIEW IF NOT EXISTS {schema_name}.{table_name} AS SELECT {select} FROM iceberg_scan({create_iceberg_str})"))
 }
 
 #[cfg(test)]

--- a/src/duckdb/parquet.rs
+++ b/src/duckdb/parquet.rs
@@ -41,6 +41,8 @@ pub enum ParquetOption {
     PreserveCasing,
     #[strum(serialize = "union_by_name")]
     UnionByName,
+    #[strum(serialize = "select")]
+    Select,
     // TODO: EncryptionConfig
 }
 
@@ -55,6 +57,7 @@ impl ParquetOption {
             Self::HiveTypes => false,
             Self::HiveTypesAutocast => false,
             Self::PreserveCasing => false,
+            Self::Select => false,
             Self::UnionByName => false,
         }
     }
@@ -114,7 +117,12 @@ pub fn create_view(
     .collect::<Vec<String>>()
     .join(", ");
 
-    Ok(format!("CREATE VIEW IF NOT EXISTS {schema_name}.{table_name} AS SELECT * FROM read_parquet({create_parquet_str})"))
+    let default_select = "*".to_string();
+    let select = table_options
+        .get(ParquetOption::Select.as_ref())
+        .unwrap_or(&default_select);
+
+    Ok(format!("CREATE VIEW IF NOT EXISTS {schema_name}.{table_name} AS SELECT {select} FROM read_parquet({create_parquet_str})"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
In DuckDB, it is possible to control which columns are selected or generate new columns in a view:

```sql
SELECT col1 as renamed_col, 1 as fixed FROM read_parquet('path/to/file.parquet');
```

We now expose this to the user so they can do the same when creating foreign tables. This is done via the new `select` option. (I couldn't name it `columns` because the CSV reader already has a `column`s option).

```sql
CREATE FOREIGN TABLE trips ()
SERVER parquet_server
OPTIONS (files 's3://paradedb-benchmarks/yellow_tripdata_2024-01.parquet', select 'vendorid as vendor_id, 2024 as year, 1 as month');

SELECT * FROM trips LIMIT 1;
 vendor_id | year | month
-----------+------+-------
         2 | 2024 |     1
(1 row)
```

## Why
This makes it possible to add generated columns to Parquet files that can be used as partition columns (will be documented in a future PR). See #56.

## How

## Tests
See added test.