### PR TITLE
ci: Add dependency check

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -47,3 +47,6 @@ jobs:
 
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings --no-deps
+
+      - name: Dependency Check
+        run: cargo install cargo-machete && cargo machete

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ pg_test = []
 
 [dependencies]
 anyhow = "1.0.83"
-arrow-buffer = "52.0.0"
 async-std = { version = "1.12.0", features = ["tokio1", "attributes"] }
 chrono = "0.4.34"
 duckdb = { git = "https://github.com/paradedb/duckdb-rs.git", features = [
@@ -30,7 +29,6 @@ pgrx = "0.12.1"
 serde = "1.0.201"
 serde_json = "1.0.120"
 signal-hook = "0.3.17"
-signal-hook-async-std = "0.2.2"
 strum = { version = "0.26.3", features = ["derive"] }
 supabase-wrappers = { git = "https://github.com/paradedb/wrappers.git", default-features = false, rev = "c6f5e79" }
 thiserror = "1.0.59"


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
This was proposed by Vipul, but was never completed. I think it's a good idea, and we've already added it to the `paradedb/paradedb` repository.

## Why
Avoid unnecessary dependencies that make our binaries bigger and slower to compile.

## How
We use `machete`

## Tests
See CI