### PR TITLE
chore: Deprecate Postgres 12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["pg16"]
-pg12 = ["pgrx/pg12", "pgrx-tests/pg12"]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Today, a vast amount of non-operational data — events, metrics, historical sna
 - [x] Delta Lake
 - [ ] JSON (Coming Soon)
 
-`pg_analytics` uses DuckDB v1.0.0 and is supported on Postgres 14, 15, and 16. Support for Postgres 12 and 13 is coming soon.
+`pg_analytics` uses DuckDB v1.0.0 and is supported on Postgres 14, 15, and 16. Support for Postgres 13 and 17 is coming soon.
 
 ## Installation
 

--- a/src/hooks/query.rs
+++ b/src/hooks/query.rs
@@ -53,18 +53,11 @@ pub fn get_query_relations(rtable: *mut pg_sys::List) -> Vec<PgRelation> {
             return relations;
         }
 
-        #[cfg(feature = "pg12")]
-        let mut current_cell = (*rtable).head;
         #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
         let elements = (*rtable).elements;
 
         for i in 0..(*rtable).length {
             let rte: *mut pg_sys::RangeTblEntry;
-            #[cfg(feature = "pg12")]
-            {
-                rte = (*current_cell).data.ptr_value as *mut pg_sys::RangeTblEntry;
-                current_cell = (*current_cell).next;
-            }
             #[cfg(any(feature = "pg13", feature = "pg14", feature = "pg15", feature = "pg16"))]
             {
                 rte = (*elements.offset(i as isize)).ptr_value as *mut pg_sys::RangeTblEntry;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #N/A

## What
It's getting deprecated by the PGDG since Postgres 17 is just about out. Also, we never actually supported it but it was somehow mentioned in a few places. No more PG12.

## Why
No longer supported.

## How
Remove code!

## Tests
It wasn't actually used, so...