### PR TITLE
fix: iceberg metadata comp codec

### DIFF
--- a/src/duckdb/iceberg.rs
+++ b/src/duckdb/iceberg.rs
@@ -74,11 +74,16 @@ pub fn create_view(
         .get(IcebergOption::SkipSchemaInference.as_ref())
         .map(|option| format!("skip_schema_inference = {option}"));
 
-    let create_iceberg_str = [files, allow_moved_paths, metadata_compression_codec, skip_schema_inference]
-        .into_iter()
-        .flatten()
-        .collect::<Vec<String>>()
-        .join(", ");
+    let create_iceberg_str = [
+        files,
+        allow_moved_paths,
+        metadata_compression_codec,
+        skip_schema_inference
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<String>>()
+    .join(", ");
 
     let default_select = "*".to_string();
     let select = table_options

--- a/src/duckdb/iceberg.rs
+++ b/src/duckdb/iceberg.rs
@@ -27,6 +27,8 @@ pub enum IcebergOption {
     AllowMovedPaths,
     #[strum(serialize = "metadata_compression_codec")]
     MetadataCompressionCodec,
+    #[strum(serialize = "skip_schema_inference")]
+    SkipSchemaInference,
     #[strum(serialize = "files")]
     Files,
     #[strum(serialize = "preserve_casing")]
@@ -40,6 +42,7 @@ impl OptionValidator for IcebergOption {
         match self {
             Self::AllowMovedPaths => false,
             Self::MetadataCompressionCodec => false,
+            Self::SkipSchemaInference => false,
             Self::Files => true,
             Self::PreserveCasing => false,
             Self::Select => false,
@@ -67,7 +70,11 @@ pub fn create_view(
         .get(IcebergOption::MetadataCompressionCodec.as_ref())
         .map(|option| format!("metadata_compression_codec = '{option}'"));
 
-    let create_iceberg_str = [files, allow_moved_paths, metadata_compression_codec]
+    let skip_schema_inference = table_options
+        .get(IcebergOption::SkipSchemaInference.as_ref())
+        .map(|option| format!("skip_schema_inference = {option}"));
+
+    let create_iceberg_str = [files, allow_moved_paths, metadata_compression_codec, skip_schema_inference]
         .into_iter()
         .flatten()
         .collect::<Vec<String>>()

--- a/src/duckdb/iceberg.rs
+++ b/src/duckdb/iceberg.rs
@@ -25,6 +25,8 @@ use crate::fdw::base::OptionValidator;
 pub enum IcebergOption {
     #[strum(serialize = "allow_moved_paths")]
     AllowMovedPaths,
+    #[strum(serialize = "metadata_compression_codec")]
+    MetadataCompressionCodec,
     #[strum(serialize = "files")]
     Files,
     #[strum(serialize = "preserve_casing")]
@@ -37,6 +39,7 @@ impl OptionValidator for IcebergOption {
     fn is_required(&self) -> bool {
         match self {
             Self::AllowMovedPaths => false,
+            Self::MetadataCompressionCodec => false,
             Self::Files => true,
             Self::PreserveCasing => false,
             Self::Select => false,
@@ -60,7 +63,11 @@ pub fn create_view(
         .get(IcebergOption::AllowMovedPaths.as_ref())
         .map(|option| format!("allow_moved_paths = {option}"));
 
-    let create_iceberg_str = [files, allow_moved_paths]
+    let metadata_compression_codec = table_options
+        .get(IcebergOption::MetadataCompressionCodec.as_ref())
+        .map(|option| format!("MetadataCompressionCodec = '{option}'"));
+
+    let create_iceberg_str = [files, allow_moved_paths, metadata_compression_codec]
         .into_iter()
         .flatten()
         .collect::<Vec<String>>()

--- a/src/duckdb/iceberg.rs
+++ b/src/duckdb/iceberg.rs
@@ -65,7 +65,7 @@ pub fn create_view(
 
     let metadata_compression_codec = table_options
         .get(IcebergOption::MetadataCompressionCodec.as_ref())
-        .map(|option| format!("MetadataCompressionCodec = '{option}'"));
+        .map(|option| format!("metadata_compression_codec = '{option}'"));
 
     let create_iceberg_str = [files, allow_moved_paths, metadata_compression_codec]
         .into_iter()

--- a/src/duckdb/iceberg.rs
+++ b/src/duckdb/iceberg.rs
@@ -73,7 +73,7 @@ pub fn create_view(
         files,
         allow_moved_paths,
         metadata_compression_codec,
-        skip_schema_inference
+        skip_schema_inference,
     ]
     .into_iter()
     .flatten()


### PR DESCRIPTION
## What
Adding support to pass option in iceberg read for metadata compression codec

## Why
It will allow users to read iceberg files for which metadata is compressed.