### PR TITLE
refactor: Use enum serialization in CSV, Delta, Iceberg, Json, Parquet, Secret, and Spatial modules

### DIFF
--- a/src/duckdb/csv.rs
+++ b/src/duckdb/csv.rs
@@ -24,74 +24,41 @@ use crate::fdw::base::OptionValidator;
 use super::utils;
 
 #[derive(EnumIter, AsRefStr, PartialEq, Debug)]
+#[strum(serialize_all = "snake_case")]
 pub enum CsvOption {
-    #[strum(serialize = "all_varchar")]
     AllVarchar,
-    #[strum(serialize = "allow_quoted_nulls")]
     AllowQuotedNulls,
-    #[strum(serialize = "auto_detect")]
     AutoDetect,
-    #[strum(serialize = "auto_type_candidates")]
     AutoTypeCandidates,
-    #[strum(serialize = "columns")]
     Columns,
-    #[strum(serialize = "compression")]
     Compression,
-    #[strum(serialize = "dateformat")]
     Dateformat,
-    #[strum(serialize = "decimal_separator")]
     DecimalSeparator,
-    #[strum(serialize = "delim")]
     Delim,
-    #[strum(serialize = "escape")]
     Escape,
-    #[strum(serialize = "filename")]
     Filename,
-    #[strum(serialize = "files")]
     Files,
-    #[strum(serialize = "force_not_null")]
     ForceNotNull,
-    #[strum(serialize = "header")]
     Header,
-    #[strum(serialize = "hive_partitioning")]
     HivePartitioning,
-    #[strum(serialize = "hive_types")]
     HiveTypes,
-    #[strum(serialize = "hive_types_autocast")]
     HiveTypesAutocast,
-    #[strum(serialize = "ignore_errors")]
     IgnoreErrors,
-    #[strum(serialize = "max_line_size")]
     MaxLineSize,
-    #[strum(serialize = "names")]
     Names,
-    #[strum(serialize = "new_line")]
     NewLine,
-    #[strum(serialize = "normalize_names")]
     NormalizeNames,
-    #[strum(serialize = "null_padding")]
     NullPadding,
-    #[strum(serialize = "nullstr")]
     Nullstr,
-    #[strum(serialize = "parallel")]
     Parallel,
-    #[strum(serialize = "preserve_casing")]
     PreserveCasing,
-    #[strum(serialize = "quote")]
     Quote,
-    #[strum(serialize = "sample_size")]
     SampleSize,
-    #[strum(serialize = "select")]
     Select,
-    #[strum(serialize = "sep")]
     Sep,
-    #[strum(serialize = "skip")]
     Skip,
-    #[strum(serialize = "timestampformat")]
     Timestampformat,
-    #[strum(serialize = "types")]
     Types,
-    #[strum(serialize = "union_by_name")]
     UnionByName,
 }
 

--- a/src/duckdb/delta.rs
+++ b/src/duckdb/delta.rs
@@ -21,12 +21,10 @@ use std::collections::HashMap;
 use strum::{AsRefStr, EnumIter};
 
 #[derive(EnumIter, AsRefStr, PartialEq, Debug)]
+#[strum(serialize_all = "snake_case")]
 pub enum DeltaOption {
-    #[strum(serialize = "files")]
     Files,
-    #[strum(serialize = "preserve_casing")]
     PreserveCasing,
-    #[strum(serialize = "select")]
     Select,
 }
 

--- a/src/duckdb/iceberg.rs
+++ b/src/duckdb/iceberg.rs
@@ -22,14 +22,11 @@ use strum::{AsRefStr, EnumIter};
 use crate::fdw::base::OptionValidator;
 
 #[derive(EnumIter, AsRefStr, PartialEq, Debug)]
+#[strum(serialize_all = "snake_case")]
 pub enum IcebergOption {
-    #[strum(serialize = "allow_moved_paths")]
     AllowMovedPaths,
-    #[strum(serialize = "files")]
     Files,
-    #[strum(serialize = "preserve_casing")]
     PreserveCasing,
-    #[strum(serialize = "select")]
     Select,
 }
 

--- a/src/duckdb/json.rs
+++ b/src/duckdb/json.rs
@@ -24,40 +24,24 @@ use crate::fdw::base::OptionValidator;
 use super::utils;
 
 #[derive(EnumIter, AsRefStr, PartialEq, Debug, Display)]
+#[strum(serialize_all = "snake_case")]
 pub enum JsonOption {
-    #[strum(serialize = "auto_detect")]
     AutoDetect,
-    #[strum(serialize = "columns")]
     Columns,
-    #[strum(serialize = "compression")]
     Compression,
-    #[strum(serialize = "convert_strings_to_integers")]
     ConvertStringsToIntegers,
-    #[strum(serialize = "dateformat")]
     Dateformat,
-    #[strum(serialize = "filename")]
     Filename,
-    #[strum(serialize = "files")]
     Files,
-    #[strum(serialize = "format")]
     Format,
-    #[strum(serialize = "hive_partitioning")]
     HivePartitioning,
-    #[strum(serialize = "ignore_errors")]
     IgnoreErrors,
-    #[strum(serialize = "maximum_depth")]
     MaximumDepth,
-    #[strum(serialize = "maximum_object_size")]
     MaximumObjectSize,
-    #[strum(serialize = "records")]
     Records,
-    #[strum(serialize = "sample_size")]
     SampleSize,
-    #[strum(serialize = "select")]
     Select,
-    #[strum(serialize = "timestampformat")]
     Timestampformat,
-    #[strum(serialize = "union_by_name")]
     UnionByName,
 }
 

--- a/src/duckdb/parquet.rs
+++ b/src/duckdb/parquet.rs
@@ -24,26 +24,17 @@ use crate::fdw::base::OptionValidator;
 use super::utils;
 
 #[derive(EnumIter, AsRefStr, PartialEq, Debug)]
+#[strum(serialize_all = "snake_case")]
 pub enum ParquetOption {
-    #[strum(serialize = "binary_as_string")]
     BinaryAsString,
-    #[strum(serialize = "filename")]
     FileName,
-    #[strum(serialize = "file_row_number")]
     FileRowNumber,
-    #[strum(serialize = "files")]
     Files,
-    #[strum(serialize = "hive_partitioning")]
     HivePartitioning,
-    #[strum(serialize = "hive_types")]
     HiveTypes,
-    #[strum(serialize = "hive_types_autocast")]
     HiveTypesAutocast,
-    #[strum(serialize = "preserve_casing")]
     PreserveCasing,
-    #[strum(serialize = "union_by_name")]
     UnionByName,
-    #[strum(serialize = "select")]
     Select,
     // TODO: EncryptionConfig
 }

--- a/src/duckdb/secret.rs
+++ b/src/duckdb/secret.rs
@@ -22,53 +22,32 @@ use strum::{AsRefStr, EnumIter};
 use crate::fdw::base::OptionValidator;
 
 #[derive(EnumIter, AsRefStr, PartialEq, Debug)]
+#[strum(serialize_all = "snake_case")]
 pub enum UserMappingOptions {
     // Universal
-    #[strum(serialize = "type")]
     Type,
-    #[strum(serialize = "provider")]
     Provider,
-    #[strum(serialize = "scope")]
     Scope,
-    #[strum(serialize = "chain")]
     Chain,
     // S3/GCS/R2
-    #[strum(serialize = "key_id")]
     KeyId,
-    #[strum(serialize = "secret")]
     Secret,
-    #[strum(serialize = "region")]
     Region,
-    #[strum(serialize = "session_token")]
     SessionToken,
-    #[strum(serialize = "endpoint")]
     Endpoint,
-    #[strum(serialize = "url_style")]
     UrlStyle,
-    #[strum(serialize = "use_ssl")]
     UseSsl,
-    #[strum(serialize = "url_compatibility_mode")]
     UrlCompatibilityMode,
-    #[strum(serialize = "account_id")]
     AccountId,
     // Azure
-    #[strum(serialize = "connection_string")]
     ConnectionString,
-    #[strum(serialize = "account_name")]
     AccountName,
-    #[strum(serialize = "tenant_id")]
     TenantId,
-    #[strum(serialize = "client_id")]
     ClientId,
-    #[strum(serialize = "client_secret")]
     ClientSecret,
-    #[strum(serialize = "client_certificate_path")]
     ClientCertificatePath,
-    #[strum(serialize = "http_proxy")]
     HttpProxy,
-    #[strum(serialize = "proxy_user_name")]
     ProxyUserName,
-    #[strum(serialize = "proxy_password")]
     ProxyPassword,
 }
 

--- a/src/duckdb/spatial.rs
+++ b/src/duckdb/spatial.rs
@@ -25,24 +25,16 @@ use crate::fdw::base::OptionValidator;
 /// SpatialOption is an enum that represents the options that can be passed to the st_read function.
 /// Reference https://github.com/duckdb/duckdb_spatial/blob/main/docs/functions.md#st_read
 #[derive(EnumIter, AsRefStr, PartialEq, Debug)]
+#[strum(serialize_all = "snake_case")]
 pub enum SpatialOption {
-    #[strum(serialize = "files")]
     Files,
-    #[strum(serialize = "sequential_layer_scan")]
     SequentialLayerScan,
-    #[strum(serialize = "spatial_filter")]
     SpatialFilter,
-    #[strum(serialize = "open_options")]
     OpenOptions,
-    #[strum(serialize = "layer")]
     Layer,
-    #[strum(serialize = "allowed_drivers")]
     AllowedDrivers,
-    #[strum(serialize = "sibling_files")]
     SiblingFiles,
-    #[strum(serialize = "spatial_filter_box")]
     SpatialFilterBox,
-    #[strum(serialize = "keep_wkb")]
     KeepWkb,
 }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What
Using `#[strum(serialize_all = "snake_case")]` to avoid naming each enum.
## Why
Easy to maintain and prevent human errors.
## How

## Tests
The related tests are existing