### PR TITLE
feat: Enable Disk Caching for Multiple Sources (Supersedes PR#30)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-traits"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,6 +1814,12 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 
 [[package]]
 name = "crossbeam-deque"
@@ -2937,6 +2952,15 @@ dependencies = [
 
 [[package]]
 name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
@@ -2974,11 +2998,24 @@ dependencies = [
 
 [[package]]
 name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version 0.4.0",
+ "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32",
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -4020,6 +4057,7 @@ dependencies = [
  "duckdb",
  "futures",
  "geojson",
+ "heapless 0.7.17",
  "pgrx",
  "pgrx-tests",
  "rstest",
@@ -4050,7 +4088,7 @@ dependencies = [
  "bitflags 2.6.0",
  "bitvec",
  "enum-map",
- "heapless",
+ "heapless 0.8.0",
  "libc",
  "once_cell",
  "pgrx-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ strum = { version = "0.26.3", features = ["derive"] }
 supabase-wrappers = { git = "https://github.com/paradedb/wrappers.git", default-features = false, rev = "c32abb7" }
 thiserror = "1.0.63"
 uuid = "1.10.0"
+heapless = "0.7.16"
 
 [dev-dependencies]
 aws-config = "1.5.6"

--- a/src/duckdb/csv.rs
+++ b/src/duckdb/csv.rs
@@ -30,6 +30,7 @@ pub enum CsvOption {
     AllowQuotedNulls,
     AutoDetect,
     AutoTypeCandidates,
+    Cache,
     Columns,
     Compression,
     Dateformat,
@@ -69,6 +70,7 @@ impl OptionValidator for CsvOption {
             Self::AllowQuotedNulls => false,
             Self::AutoDetect => false,
             Self::AutoTypeCandidates => false,
+            Self::Cache => false,
             Self::Columns => false,
             Self::Compression => false,
             Self::Dateformat => false,
@@ -103,7 +105,7 @@ impl OptionValidator for CsvOption {
     }
 }
 
-pub fn create_view(
+pub fn create_duckdb_relation(
     table_name: &str,
     schema_name: &str,
     table_options: HashMap<String, String>,
@@ -277,12 +279,14 @@ pub fn create_view(
     .collect::<Vec<String>>()
     .join(", ");
 
-    let default_select = "*".to_string();
-    let select = table_options
-        .get(CsvOption::Select.as_ref())
-        .unwrap_or(&default_select);
+    let cache = table_options
+        .get(CsvOption::Cache.as_ref())
+        .map(|s| s.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
 
-    Ok(format!("CREATE VIEW IF NOT EXISTS {schema_name}.{table_name} AS SELECT {select} FROM read_csv({create_csv_str})"))
+    let relation = if cache { "TABLE" } else { "VIEW" };
+
+    Ok(format!("CREATE {relation} IF NOT EXISTS {schema_name}.{table_name} AS SELECT * FROM read_csv({create_csv_str})"))
 }
 
 #[cfg(test)]
@@ -291,7 +295,7 @@ mod tests {
     use duckdb::Connection;
 
     #[test]
-    fn test_create_csv_view_single_file() {
+    fn test_create_csv_relation_single_file() {
         let table_name = "test";
         let schema_name = "main";
         let table_options = HashMap::from([(
@@ -300,7 +304,7 @@ mod tests {
         )]);
         let expected =
             "CREATE VIEW IF NOT EXISTS main.test AS SELECT * FROM read_csv('/data/file.csv')";
-        let actual = create_view(table_name, schema_name, table_options).unwrap();
+        let actual = create_duckdb_relation(table_name, schema_name, table_options).unwrap();
 
         assert_eq!(expected, actual);
 
@@ -312,7 +316,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_csv_view_multiple_files() {
+    fn test_create_csv_relation_multiple_files() {
         let table_name = "test";
         let schema_name = "main";
         let table_options = HashMap::from([(
@@ -321,7 +325,7 @@ mod tests {
         )]);
 
         let expected = "CREATE VIEW IF NOT EXISTS main.test AS SELECT * FROM read_csv(['/data/file1.csv', '/data/file2.csv'])";
-        let actual = create_view(table_name, schema_name, table_options).unwrap();
+        let actual = create_duckdb_relation(table_name, schema_name, table_options).unwrap();
 
         assert_eq!(expected, actual);
 
@@ -333,7 +337,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_csv_view_with_options() {
+    fn test_create_csv_relation_with_options() {
         let table_name = "test";
         let schema_name = "main";
         let table_options = HashMap::from([
@@ -441,7 +445,7 @@ mod tests {
         ]);
 
         let expected = "CREATE VIEW IF NOT EXISTS main.test AS SELECT * FROM read_csv('/data/file.csv', all_varchar = true, allow_quoted_nulls = true, auto_detect = true, auto_type_candidates = ['BIGINT', 'DATE'], columns = {'col1': 'INTEGER', 'col2': 'VARCHAR'}, compression = 'gzip', dateformat = '%d/%m/%Y', decimal_separator = '.', delim = ',', escape = '\"', filename = true, force_not_null = ['col1', 'col2'], header = true, hive_partitioning = true, hive_types = true, hive_types_autocast = true, ignore_errors = true, max_line_size = 1000, names = ['col1', 'col2'], new_line = '\n', normalize_names = true, null_padding = true, nullstr = ['none', 'null'], parallel = true, quote = '\"', sample_size = 100, sep = ',', skip = 0, timestampformat = 'yyyy-MM-dd HH:mm:ss', types = ['BIGINT', 'VARCHAR'], union_by_name = true)";
-        let actual = create_view(table_name, schema_name, table_options).unwrap();
+        let actual = create_duckdb_relation(table_name, schema_name, table_options).unwrap();
 
         assert_eq!(expected, actual);
 

--- a/src/duckdb/json.rs
+++ b/src/duckdb/json.rs
@@ -51,7 +51,7 @@ impl OptionValidator for JsonOption {
     }
 }
 
-pub fn create_view(
+pub fn create_duckdb_relation(
     table_name: &str,
     schema_name: &str,
     table_options: HashMap<String, String>,
@@ -119,7 +119,7 @@ mod tests {
         )]);
 
         let expected = "CREATE VIEW IF NOT EXISTS main.json_test AS SELECT * FROM read_json('/data/file1.json')";
-        let actual = create_view(table_name, schema_name, table_options).unwrap();
+        let actual = create_duckdb_relation(table_name, schema_name, table_options).unwrap();
 
         assert_eq!(expected, actual);
 
@@ -175,7 +175,7 @@ mod tests {
         ]);
 
         let expected = "CREATE VIEW IF NOT EXISTS main.json_test AS SELECT key1 FROM read_json(['/data/file1.json', '/data/file2.json'], columns = {'key1': 'INTEGER', 'key2': 'VARCHAR'}, compression = 'uncompressed', convert_strings_to_integers = false, dateformat = '%d/%m/%Y', filename = true, format = 'array', hive_partitioning = false, ignore_errors = true, maximum_depth = 4096, maximum_object_size = 65536, records = auto, sample_size = -1, timestampformat = 'yyyy-MM-dd', union_by_name = true)";
-        let actual = create_view(table_name, schema_name, table_options).unwrap();
+        let actual = create_duckdb_relation(table_name, schema_name, table_options).unwrap();
 
         assert_eq!(expected, actual);
 

--- a/src/duckdb/parquet.rs
+++ b/src/duckdb/parquet.rs
@@ -27,6 +27,7 @@ use super::utils;
 #[strum(serialize_all = "snake_case")]
 pub enum ParquetOption {
     BinaryAsString,
+    Cache,
     FileName,
     FileRowNumber,
     Files,
@@ -43,6 +44,7 @@ impl OptionValidator for ParquetOption {
     fn is_required(&self) -> bool {
         match self {
             Self::BinaryAsString => false,
+            Self::Cache => false,
             Self::FileName => false,
             Self::FileRowNumber => false,
             Self::Files => true,
@@ -50,13 +52,13 @@ impl OptionValidator for ParquetOption {
             Self::HiveTypes => false,
             Self::HiveTypesAutocast => false,
             Self::PreserveCasing => false,
-            Self::Select => false,
             Self::UnionByName => false,
+            Self::Select => false,
         }
     }
 }
 
-pub fn create_view(
+pub fn create_duckdb_relation(
     table_name: &str,
     schema_name: &str,
     table_options: HashMap<String, String>,
@@ -110,12 +112,14 @@ pub fn create_view(
     .collect::<Vec<String>>()
     .join(", ");
 
-    let default_select = "*".to_string();
-    let select = table_options
-        .get(ParquetOption::Select.as_ref())
-        .unwrap_or(&default_select);
+    let cache = table_options
+        .get(ParquetOption::Cache.as_ref())
+        .map(|s| s.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
 
-    Ok(format!("CREATE VIEW IF NOT EXISTS {schema_name}.{table_name} AS SELECT {select} FROM read_parquet({create_parquet_str})"))
+    let relation = if cache { "TABLE" } else { "VIEW" };
+
+    Ok(format!("CREATE {relation} IF NOT EXISTS {schema_name}.{table_name} AS SELECT * FROM read_parquet({create_parquet_str})"))
 }
 
 #[cfg(test)]
@@ -124,14 +128,14 @@ mod tests {
     use duckdb::Connection;
 
     #[test]
-    fn test_create_parquet_view_single_file() {
+    fn test_create_parquet_relation_single_file() {
         let table_name = "test";
         let schema_name = "main";
         let files = "/data/file.parquet";
         let table_options =
             HashMap::from([(ParquetOption::Files.as_ref().to_string(), files.to_string())]);
         let expected = "CREATE VIEW IF NOT EXISTS main.test AS SELECT * FROM read_parquet('/data/file.parquet')";
-        let actual = create_view(table_name, schema_name, table_options).unwrap();
+        let actual = create_duckdb_relation(table_name, schema_name, table_options).unwrap();
 
         assert_eq!(expected, actual);
 
@@ -143,7 +147,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_parquet_view_multiple_files() {
+    fn test_create_parquet_relation_multiple_files() {
         let table_name = "test";
         let schema_name = "main";
         let files = "/data/file1.parquet, /data/file2.parquet";
@@ -151,7 +155,7 @@ mod tests {
             HashMap::from([(ParquetOption::Files.as_ref().to_string(), files.to_string())]);
 
         let expected = "CREATE VIEW IF NOT EXISTS main.test AS SELECT * FROM read_parquet(['/data/file1.parquet', '/data/file2.parquet'])";
-        let actual = create_view(table_name, schema_name, table_options).unwrap();
+        let actual = create_duckdb_relation(table_name, schema_name, table_options).unwrap();
 
         assert_eq!(expected, actual);
 
@@ -163,7 +167,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_parquet_view_with_options() {
+    fn test_create_parquet_relation_with_options() {
         let table_name = "test";
         let schema_name = "main";
         let table_options = HashMap::from([
@@ -202,7 +206,7 @@ mod tests {
         ]);
 
         let expected = "CREATE VIEW IF NOT EXISTS main.test AS SELECT * FROM read_parquet('/data/file.parquet', binary_as_string = true, filename = false, file_row_number = true, hive_partitioning = true, hive_types = {'release': DATE, 'orders': BIGINT}, hive_types_autocast = true, union_by_name = true)";
-        let actual = create_view(table_name, schema_name, table_options).unwrap();
+        let actual = create_duckdb_relation(table_name, schema_name, table_options).unwrap();
 
         assert_eq!(expected, actual);
 

--- a/src/duckdb/spatial.rs
+++ b/src/duckdb/spatial.rs
@@ -28,6 +28,7 @@ use crate::fdw::base::OptionValidator;
 #[strum(serialize_all = "snake_case")]
 pub enum SpatialOption {
     Files,
+    Cache,
     SequentialLayerScan,
     SpatialFilter,
     OpenOptions,
@@ -42,6 +43,7 @@ impl OptionValidator for SpatialOption {
     fn is_required(&self) -> bool {
         match self {
             Self::Files => true,
+            Self::Cache => false,
             Self::SequentialLayerScan => false,
             Self::SpatialFilter => false,
             Self::OpenOptions => false,
@@ -54,7 +56,7 @@ impl OptionValidator for SpatialOption {
     }
 }
 
-pub fn create_view(
+pub fn create_duckdb_relation(
     table_name: &str,
     schema_name: &str,
     table_options: HashMap<String, String>,
@@ -73,8 +75,15 @@ pub fn create_view(
         })
         .collect::<Vec<String>>();
 
+    let cache = table_options
+        .get(SpatialOption::Cache.as_ref())
+        .map(|s| s.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    let relation = if cache { "TABLE" } else { "VIEW" };
+
     Ok(format!(
-        "CREATE VIEW IF NOT EXISTS {}.{} AS SELECT * FROM st_read({})",
+        "CREATE {relation} IF NOT EXISTS {}.{} AS SELECT * FROM st_read({})",
         schema_name,
         table_name,
         spatial_options.join(", "),
@@ -97,7 +106,7 @@ mod tests {
 
         let expected =
             "CREATE VIEW IF NOT EXISTS main.test AS SELECT * FROM st_read('/data/spatial')";
-        let actual = create_view(table_name, schema_name, table_options).unwrap();
+        let actual = create_duckdb_relation(table_name, schema_name, table_options).unwrap();
 
         assert_eq!(expected, actual);
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,0 +1,131 @@
+use anyhow::{anyhow, Result};
+use duckdb::Connection;
+use pgrx::*;
+use std::ffi::CStr;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+// One connection per database, so 128 databases can have a DuckDB connection
+const MAX_CONNECTIONS: usize = 128;
+pub static DUCKDB_CONNECTION_CACHE: PgLwLock<DuckdbConnection> = PgLwLock::new();
+
+pub struct DuckdbConnection {
+    conn_map: heapless::FnvIndexMap<u32, DuckdbConnectionInner, MAX_CONNECTIONS>,
+    conn_lru: heapless::Deque<u32, MAX_CONNECTIONS>,
+}
+
+unsafe impl PGRXSharedMemory for DuckdbConnection {}
+
+impl Default for DuckdbConnection {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DuckdbConnection {
+    fn new() -> Self {
+        Self {
+            conn_map: heapless::FnvIndexMap::<_, _, MAX_CONNECTIONS>::new(),
+            conn_lru: heapless::Deque::<_, MAX_CONNECTIONS>::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct DuckdbConnectionInner(Arc<Mutex<Connection>>);
+
+impl Default for DuckdbConnectionInner {
+    fn default() -> Self {
+        let mut duckdb_path = postgres_data_dir_path();
+        duckdb_path.push("pg_analytics");
+
+        if !duckdb_path.exists() {
+            std::fs::create_dir_all(duckdb_path.clone())
+                .expect("failed to create duckdb data directory");
+        }
+
+        duckdb_path.push(postgres_database_oid().to_string());
+        duckdb_path.set_extension("db3");
+
+        let conn = Connection::open(duckdb_path).expect("failed to open duckdb connection");
+        DuckdbConnectionInner(Arc::new(Mutex::new(conn)))
+    }
+}
+
+fn postgres_data_dir_path() -> PathBuf {
+    let data_dir = unsafe {
+        CStr::from_ptr(pg_sys::DataDir)
+            .to_string_lossy()
+            .into_owned()
+    };
+    PathBuf::from(data_dir)
+}
+
+fn postgres_database_oid() -> u32 {
+    unsafe { pg_sys::MyDatabaseId.as_u32() }
+}
+
+#[macro_export]
+macro_rules! with_connection {
+    ($body:expr) => {{
+        let conn = get_global_connection()?;
+        let conn = conn
+            .lock()
+            .map_err(|e| anyhow!("Failed to acquire lock: {}", e))?;
+        $body(&*conn) // Dereference the MutexGuard to get &Connection
+    }};
+}
+
+pub fn get_global_connection() -> Result<Arc<Mutex<Connection>>> {
+    let database_id = postgres_database_oid();
+    let mut cache = DUCKDB_CONNECTION_CACHE.exclusive();
+
+    if cache.conn_map.contains_key(&database_id) {
+        // Move the accessed connection to the back of the LRU queue
+        let mut new_lru = heapless::Deque::<_, MAX_CONNECTIONS>::new();
+        for &id in cache.conn_lru.iter() {
+            if id != database_id {
+                new_lru
+                    .push_back(id)
+                    .unwrap_or_else(|_| panic!("Failed to push to LRU queue"));
+            }
+        }
+        new_lru
+            .push_back(database_id)
+            .unwrap_or_else(|_| panic!("Failed to push to LRU queue"));
+        cache.conn_lru = new_lru;
+
+        // Now we can safely borrow conn_map again
+        Ok(cache.conn_map.get(&database_id).unwrap().0.clone())
+    } else {
+        if cache.conn_map.len() >= MAX_CONNECTIONS {
+            if let Some(least_recently_used) = cache.conn_lru.pop_front() {
+                cache.conn_map.remove(&least_recently_used);
+            }
+        }
+        let conn = DuckdbConnectionInner::default();
+        cache
+            .conn_map
+            .insert(database_id, conn.clone())
+            .map_err(|_| anyhow!("Failed to insert into connection map"))?;
+        cache
+            .conn_lru
+            .push_back(database_id)
+            .map_err(|_| anyhow!("Failed to push to LRU queue"))?;
+        Ok(conn.0)
+    }
+}
+
+pub fn interrupt_all_connections() -> Result<()> {
+    let cache = DUCKDB_CONNECTION_CACHE.exclusive();
+    for &database_id in cache.conn_lru.iter() {
+        if let Some(conn) = cache.conn_map.get(&database_id) {
+            let conn = conn
+                .0
+                .lock()
+                .map_err(|e| anyhow::anyhow!("Failed to acquire lock: {}", e))?;
+            conn.interrupt();
+        }
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod api;
 #[cfg(debug_assertions)]
 mod debug_guc;
 mod duckdb;
+mod env;
 mod fdw;
 mod hooks;
 mod schema;
@@ -41,15 +42,14 @@ static mut EXTENSION_HOOK: ExtensionHook = ExtensionHook;
 
 #[pg_guard]
 pub extern "C" fn _PG_init() {
+    pgrx::warning!("pga:: extension is being initialized");
     #[allow(static_mut_refs)]
     #[allow(deprecated)]
     unsafe {
         register_hook(&mut EXTENSION_HOOK)
     };
 
-    // TODO: Depends on above TODO
-    // GUCS.init("pg_analytics");
-    // setup_telemetry_background_worker(ParadeExtension::PgAnalytics);
+    pg_shmem_init!(env::DUCKDB_CONNECTION_CACHE);
 
     #[cfg(debug_assertions)]
     DEBUG_GUCS.init();


### PR DESCRIPTION
**This PR is part of a pair; please review, validate, and consider merging both.**

https://github.com/paradedb/paradedb/pull/1751
https://github.com/paradedb/pg_analytics/pull/148

**Scope of this PR:**

This PR supersedes the following previous submissions:
- https://github.com/paradedb/paradedb/pull/1703
- https://github.com/paradedb/pg_analytics/pull/131

It is based on consolidated requirements and feedback from the review comments on the above closed PRs.

## What

- This PR separates the core implementation from [PR#30](https://github.com/paradedb/pg_analytics/pull/30), focusing on enabling disk caching for various sources supported by `pg_analytics`.
- The benchmarking, specifically for Hive-style partitioned Parquet sources, leverages this core disk cache functionality and is implemented in `paradedb/cargo-paradedb/src/pga_benches/pga_benchlogs_hsp_pq.rs`.

## Why

## How
