### PR TITLE
test: add a test of creating a foreign table with reserved column name

### DIFF
--- a/src/fdw/trigger.rs
+++ b/src/fdw/trigger.rs
@@ -281,11 +281,7 @@ fn construct_alter_table_statement(
                 column_name.to_string()
             };
 
-            format!(
-                "ADD COLUMN {} {}",
-                spi::quote_identifier(column_name),
-                pg_type
-            )
+            format!("ADD COLUMN {} {}", column_name, pg_type)
         })
         .collect();
 

--- a/src/fdw/trigger.rs
+++ b/src/fdw/trigger.rs
@@ -281,7 +281,11 @@ fn construct_alter_table_statement(
                 column_name.to_string()
             };
 
-            format!("ADD COLUMN {} {}", column_name, pg_type)
+            format!(
+                "ADD COLUMN {} {}",
+                spi::quote_identifier(column_name),
+                pg_type
+            )
         })
         .collect();
 

--- a/tests/tests/fixtures/arrow.rs
+++ b/tests/tests/fixtures/arrow.rs
@@ -245,10 +245,15 @@ pub fn primitive_record_batch_single() -> Result<RecordBatch> {
 }
 
 pub fn reserved_column_record_batch() -> Result<RecordBatch> {
-    // INTEGER authorization is a reserved column name
+    // authorization is a reserved column name
     let fields = vec![
-        Field::new("INTEGER", DataType::Int32, false),
+        Field::new("id", DataType::Utf8, false),
+        Field::new("operation_id", DataType::Utf8, false),
+        Field::new("order_id", DataType::Utf8, false),
+        Field::new("dealer_id", DataType::Utf8, false),
+        Field::new("dealer_name", DataType::Utf8, false),
         Field::new("authorization", DataType::Utf8, false),
+        Field::new("on_day", DataType::Boolean, false),
     ];
 
     let schema = Arc::new(Schema::new(fields));
@@ -256,11 +261,24 @@ pub fn reserved_column_record_batch() -> Result<RecordBatch> {
     Ok(RecordBatch::try_new(
         schema,
         vec![
-            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec![Some("1"), Some("2"), Some("3")])),
+            Arc::new(StringArray::from(vec![Some("1"), Some("2"), Some("3")])),
+            Arc::new(StringArray::from(vec![Some("1"), Some("2"), Some("3")])),
+            Arc::new(StringArray::from(vec![Some("1"), Some("2"), Some("3")])),
+            Arc::new(StringArray::from(vec![
+                Some("Jason"),
+                Some("Alice"),
+                Some("Bob"),
+            ])),
             Arc::new(StringArray::from(vec![
                 Some("auth_1"),
                 Some("auth_2"),
                 Some("auth_3"),
+            ])),
+            Arc::new(BooleanArray::from(vec![
+                Some(true),
+                Some(false),
+                Some(true),
             ])),
         ],
     )?)

--- a/tests/tests/fixtures/arrow.rs
+++ b/tests/tests/fixtures/arrow.rs
@@ -244,6 +244,28 @@ pub fn primitive_record_batch_single() -> Result<RecordBatch> {
     )?)
 }
 
+pub fn reserved_column_record_batch() -> Result<RecordBatch> {
+    // INTEGER authorization is a reserved column name
+    let fields = vec![
+        Field::new("INTEGER", DataType::Int32, false),
+        Field::new("authorization", DataType::Utf8, false),
+    ];
+
+    let schema = Arc::new(Schema::new(fields));
+
+    Ok(RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec![
+                Some("auth_1"),
+                Some("auth_2"),
+                Some("auth_3"),
+            ])),
+        ],
+    )?)
+}
+
 pub fn primitive_create_foreign_data_wrapper(
     wrapper: &str,
     handler: &str,

--- a/tests/tests/table_config.rs
+++ b/tests/tests/table_config.rs
@@ -105,7 +105,7 @@ fn test_reserved_column_name(mut conn: PgConnection, tempdir: TempDir) -> Result
     setup_parquet_wrapper_and_server().execute(&mut conn);
 
     match format!(
-        "CREATE FOREIGN TABLE reserved_table_name () SERVER parquet_server OPTIONS (files '{}')",
+        "CREATE FOREIGN TABLE reserved_table_name () SERVER parquet_server OPTIONS (files '{}', preserve_casing 'true')",
         parquet_path.to_str().unwrap()
     )
     .execute_result(&mut conn)

--- a/tests/tests/table_config.rs
+++ b/tests/tests/table_config.rs
@@ -19,7 +19,8 @@ mod fixtures;
 
 use crate::fixtures::arrow::{
     primitive_record_batch, primitive_setup_fdw_local_file_listing, record_batch_with_casing,
-    setup_local_file_listing_with_casing,
+    reserved_column_record_batch, setup_local_file_listing_with_casing,
+    setup_parquet_wrapper_and_server,
 };
 use crate::fixtures::db::Query;
 use crate::fixtures::{conn, tempdir};
@@ -85,6 +86,33 @@ async fn test_reserved_table_name(mut conn: PgConnection, tempdir: TempDir) -> R
         }
         Err(e) => {
             assert_eq!(e.to_string(), "error returned from database: Table name 'duckdb_types' is not allowed because it is reserved by DuckDB")
+        }
+    }
+
+    Ok(())
+}
+
+#[rstest]
+fn test_reserved_column_name(mut conn: PgConnection, tempdir: TempDir) -> Result<()> {
+    let stored_batch = reserved_column_record_batch()?;
+    let parquet_path = tempdir.path().join("reserved_column_table.parquet");
+    let parquet_file = File::create(&parquet_path).unwrap();
+
+    let mut writer = ArrowWriter::try_new(parquet_file, stored_batch.schema(), None).unwrap();
+    writer.write(&stored_batch)?;
+    writer.close()?;
+
+    setup_parquet_wrapper_and_server().execute(&mut conn);
+
+    match format!(
+        "CREATE FOREIGN TABLE reserved_table_name () SERVER parquet_server OPTIONS (files '{}')",
+        parquet_path.to_str().unwrap()
+    )
+    .execute_result(&mut conn)
+    {
+        Ok(_) => {}
+        Err(e) => {
+            panic!("fail to create table with reserved column name: {}", e)
         }
     }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #177 

## What

## Why

## How
Add the option preserve_casing 'true' to ensure that reserved column names are correctly created.
## Tests
add a test of creating foreign table with reserved column name