### PR TITLE
fix: Fix misleading the warning log during initdb

### DIFF
--- a/src/hooks/utility.rs
+++ b/src/hooks/utility.rs
@@ -55,7 +55,9 @@ pub async fn process_utility_hook(
 ) -> Result<()> {
     let stmt_type = unsafe { (*pstmt.utilityStmt).type_ };
 
-    if !is_support_utility(stmt_type) {
+    // IsPostmasterEnvironment is false when it is false in a standalone process (bootstrap or
+    // standalone backend).
+    if !is_support_utility(stmt_type) || unsafe { !pg_sys::IsPostmasterEnvironment } {
         prev_hook(
             pstmt,
             query_string,

--- a/src/hooks/utility/view.rs
+++ b/src/hooks/utility/view.rs
@@ -83,7 +83,6 @@ pub fn view_query(
             if (*planned_stmt).commandType != pg_sys::CmdType::CMD_SELECT
                 || !is_duckdb_query(&query_relations)
             {
-                fallback_warning!("Some relations are not in DuckDB");
                 return Ok(true);
             }
         }
@@ -91,6 +90,9 @@ pub fn view_query(
 
     // Push down the view creation query to DuckDB
     set_search_path_by_pg()?;
-    execute(query_string.to_str()?, [])?;
+    if let Err(e) = execute(query_string.to_str()?, []) {
+        fallback_warning!(e.to_string());
+    }
+
     Ok(true)
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #189 

## What
Fix misleading the warning log during initdb
## Why

## How
Disable utility hooks during initdb. If relations do not exist in Duckdb, it shouldn't print warning logs.
## Tests
