### PR TITLE
ci: Add PGXN META.json and release workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+.gitignore export-ignore
+.gitattributes export-ignore
+.github export-ignore
+.markdownlint.yaml export-ignore
+.pre-commit-config.yaml export-ignore
+META.json.in export-ignore

--- a/.github/workflows/pgxn-release.yml
+++ b/.github/workflows/pgxn-release.yml
@@ -1,0 +1,20 @@
+name: 🚀 Release on PGXN
+on:
+  push:
+    # Release on semantic version tag.
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+jobs:
+  release:
+    name: Release on PGXN
+    runs-on: ubuntu-latest
+    container: pgxn/pgxn-tools
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Bundle the Release
+        run: make dist
+      - name: Release on PGXN
+        env:
+          PGXN_USERNAME: ${{ secrets.PGXN_USERNAME }}
+          PGXN_PASSWORD: ${{ secrets.PGXN_PASSWORD }}
+        run: pgxn-release

--- a/.github/workflows/publish-pg_analytics-pgxn.yml
+++ b/.github/workflows/publish-pg_analytics-pgxn.yml
@@ -1,18 +1,29 @@
-name: 🚀 Release on PGXN
+# workflows/publish-pg_analytics-pgxn.yml
+#
+# Publish pg_analytics (PGXN)
+# Build and publish the pg_analytics extension to the PostgreSQL Extension Network (PGXN).
+
+name: Publish pg_analytics (PGXN)
+
 on:
   push:
-    # Release on semantic version tag.
-    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+    tags:
+      - "v*"
+  workflow_dispatch:
+
 jobs:
-  release:
-    name: Release on PGXN
+  publish-pg_analytics:
+    name: Publish pg_analytics to PGXN
     runs-on: ubuntu-latest
     container: pgxn/pgxn-tools
+
     steps:
-      - name: Check out the repo
+      - name: Checkout Git Repository
         uses: actions/checkout@v4
+
       - name: Bundle the Release
         run: make dist
+
       - name: Release on PGXN
         env:
           PGXN_USERNAME: ${{ secrets.PGXN_USERNAME }}

--- a/META.json.in
+++ b/META.json.in
@@ -1,0 +1,53 @@
+{
+   "name": "pg_analytics",
+   "abstract": "DuckDB-powered data lake analytics from Postgres",
+   "description": "pg_analytics puts DuckDB inside Postgres. With pg_analytics installed, Postgres can query foreign object stores like AWS S3 and table formats like Iceberg or Delta Lake. Queries are pushed down to DuckDB, a high performance analytical query engine.",
+   "version": "@CARGO_VERSION@",
+   "maintainer": [
+      "Philippe Noël <phil@paradedb.com>"
+   ],
+   "license": "postgresql",
+   "provides": {
+      "pg_analytics": {
+         "abstract": "Postgres for analytics, powered by DuckDB",
+         "file": "src/lib.rs",
+         "docfile": "doc/overview.mdx",
+         "version": "@CARGO_VERSION@"
+      }
+   },
+   "prereqs": {
+      "runtime": {
+         "requires": {
+            "PostgreSQL": "13.0.0"
+         }
+      }
+   },
+   "resources": {
+      "bugtracker": {
+         "web": "https://github.com/paradedb/pg_analytics/issues/"
+      },
+      "repository": {
+         "url": "git://github.com/paradedb/pg_analytics.git",
+         "web": "https://github.com/paradedb/pg_analytics/",
+         "type": "git"
+      }
+   },
+   "generated_by": "David E. Wheeler",
+   "meta-spec": {
+      "version": "1.0.0",
+      "url": "https://pgxn.org/meta/spec.txt"
+   },
+   "tags": [
+      "analytics",
+      "big data",
+      "olap",
+      "parquet",
+      "iceberg",
+      "object storage",
+      "datalake",
+      "arrow",
+      "realtime analytics",
+      "columnar",
+      "duckdb"
+   ]
+}

--- a/META.json.in
+++ b/META.json.in
@@ -1,7 +1,7 @@
 {
    "name": "pg_analytics",
    "abstract": "DuckDB-powered data lake analytics from Postgres",
-   "description": "pg_analytics puts DuckDB inside Postgres. With pg_analytics installed, Postgres can query foreign object stores like AWS S3 and table formats like Iceberg or Delta Lake. Queries are pushed down to DuckDB, a high performance analytical query engine.",
+   "description": "pg_analytics puts DuckDB inside Postgres. With pg_analytics installed, Postgres can query foreign object stores like AWS S3 and table formats like Iceberg or Delta Lake. Queries are pushed down to DuckDB, a high-performance analytical query engine.",
    "version": "@CARGO_VERSION@",
    "maintainer": [
       "Philippe Noël <phil@paradedb.com>"
@@ -9,7 +9,7 @@
    "license": "postgresql",
    "provides": {
       "pg_analytics": {
-         "abstract": "Postgres for analytics, powered by DuckDB",
+         "abstract": "DuckDB-powered data lake analytics from Postgres",
          "file": "src/lib.rs",
          "docfile": "doc/overview.mdx",
          "version": "@CARGO_VERSION@"

--- a/META.json.in
+++ b/META.json.in
@@ -38,6 +38,7 @@
       "url": "https://pgxn.org/meta/spec.txt"
    },
    "tags": [
+      "paradedb",
       "analytics",
       "big data",
       "olap",

--- a/META.json.in
+++ b/META.json.in
@@ -4,7 +4,7 @@
    "description": "pg_analytics puts DuckDB inside Postgres. With pg_analytics installed, Postgres can query foreign object stores like AWS S3 and table formats like Iceberg or Delta Lake. Queries are pushed down to DuckDB, a high-performance analytical query engine.",
    "version": "@CARGO_VERSION@",
    "maintainer": [
-      "Philippe Noël <phil@paradedb.com>"
+      "ParadeDB <support@paradedb.com>"
    ],
    "license": "postgresql",
    "provides": {

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+DISTNAME = $(shell grep -m 1 '^name' Cargo.toml | sed -e 's/[^"]*"\([^"]*\)",\{0,1\}/\1/')
+DISTVERSION  = $(shell grep -m 1 '^version' Cargo.toml | sed -e 's/[^"]*"\([^"]*\)",\{0,1\}/\1/')
+
+META.json: META.json.in Cargo.toml
+	@sed "s/@CARGO_VERSION@/$(DISTVERSION)/g" $< > $@
+
+$(DISTNAME)-$(DISTVERSION).zip: META.json
+	git archive --format zip --prefix $(DISTNAME)-$(DISTVERSION)/ --add-file $< -o $(DISTNAME)-$(DISTVERSION).zip HEAD
+
+dist: $(DISTNAME)-$(DISTVERSION).zip
+
+clean:
+	@rm -rf META.json $(DISTNAME)-$(DISTVERSION).zip


### PR DESCRIPTION
Add a `Makefile` to automate populating the version in the `META.json` and creating the zip file. `.gitattributes` prevents unnecessary files from inclusion in the zip file. `.github/workflows/pgxn-release.yml` uses the `pgxn/pgxn-tools` OCI to publish the zip file on PGXN when a server tag is pushed.

To actually  publish on PGXN, you'll need to follow these steps:

1. [Request a PGXN account](https://manager.pgxn.org/account/register). I will approve it ASAP.
2. Once approved, log in and set a password.
3. Navigate to either Actions and secrets [for this repo](https://github.com/paradedb/pg_analytics/settings/secrets/actions) or, if you'd like to use the same credentials to publish other extensions on PGXN, [for the ParadeDB org](https://github.com/organizations/paradedb/settings/secrets/actions).
4. Hit the "New Repository Secret" or "New Organization Secret" button for each of these two secrets to create them:
    * `PGXN_USERNAME`: Your PGXN username
    * `PGXN_PASSWORD`: Your PGXN password

The extension will be published on PGXN the next time you push a tag. If you'd like to publish sooner, simply comment out the `tags: ['v[0-9]+.[0-9]+.[0-9]+']` line, push it, let it publish, then uncomment the line to trigger on future tag pushes.