### PR TITLE
fix: move loading `httpfs` and setting extension directory to beginning of connection

### DIFF
--- a/src/duckdb/connection.rs
+++ b/src/duckdb/connection.rs
@@ -269,7 +269,11 @@ pub fn set_duckdb_extension_directory(conn: &Connection) -> Result<usize> {
             .to_str()
             .map_err(|e| anyhow::anyhow!("Failed to convert DataDir to &str: {}", e))?
     };
-    conn.execute(format!("SET extension_directory = '{data_dir}'").as_str(), []).map_err(|err| anyhow!("{err}"))
+    conn.execute(
+        format!("SET extension_directory = '{data_dir}'").as_str(),
+        [],
+    )
+    .map_err(|err| anyhow!("{err}"))
 }
 
 pub fn execute_explain(query: &str) -> Result<String> {

--- a/src/duckdb/connection.rs
+++ b/src/duckdb/connection.rs
@@ -44,7 +44,7 @@ fn init_globals() {
 
     // Force DuckDB to install its extensions in the PGDATA directory, which is writable,
     // in case the rest of the filesystem is read-only
-    let _ = set_duckdb_extension_directory().expect("failed to set duckdb extension directory");
+    let _ = set_duckdb_extension_directory(&conn).expect("failed to set duckdb extension directory");
 
     // duckdb-rs stopped bundling in httpfs, so we need to load it ourselves
     install_httpfs().expect("failed to install httpfs");

--- a/src/duckdb/connection.rs
+++ b/src/duckdb/connection.rs
@@ -43,7 +43,10 @@ fn init_globals() {
         set_duckdb_extension_directory(&conn).expect("failed to set duckdb extension directory");
 
     // duckdb-rs stopped bundling in httpfs, so we need to load it ourselves
-    install_httpfs(&conn).expect("failed to install httpfs");
+    conn.execute("INSTALL httpfs", [])
+        .expect("failed to install httpfs");
+    conn.execute("LOAD httpfs", [])
+        .expect("failed to load httpfs");
 
     unsafe {
         GLOBAL_CONNECTION = Some(UnsafeCell::new(conn));
@@ -294,12 +297,4 @@ pub fn execute_explain(query: &str) -> Result<String> {
     })?;
 
     Ok(rows.join(""))
-}
-
-pub fn install_httpfs(conn: &Connection) -> Result<()> {
-    if !check_extension_loaded("httpfs")? {
-        conn.execute("INSTALL httpfs", [])?;
-        conn.execute("LOAD httpfs", [])?;
-    }
-    Ok(())
 }

--- a/src/duckdb/connection.rs
+++ b/src/duckdb/connection.rs
@@ -36,15 +36,17 @@ static INIT: Once = Once::new();
 
 fn init_globals() {
     let conn = Connection::open_in_memory().expect("failed to open duckdb connection");
+
+    // Force DuckDB to install its extensions in the PGDATA directory, which is writable,
+    // in case the rest of the filesystem is read-only
+    let _ =
+        set_duckdb_extension_directory(&conn).expect("failed to set duckdb extension directory");
+
     unsafe {
         GLOBAL_CONNECTION = Some(UnsafeCell::new(conn));
         GLOBAL_STATEMENT = Some(UnsafeCell::new(None));
         GLOBAL_ARROW = Some(UnsafeCell::new(None));
     }
-
-    // Force DuckDB to install its extensions in the PGDATA directory, which is writable,
-    // in case the rest of the filesystem is read-only
-    let _ = set_duckdb_extension_directory(&conn).expect("failed to set duckdb extension directory");
 
     // duckdb-rs stopped bundling in httpfs, so we need to load it ourselves
     install_httpfs().expect("failed to install httpfs");

--- a/src/duckdb/connection.rs
+++ b/src/duckdb/connection.rs
@@ -42,14 +42,14 @@ fn init_globals() {
     let _ =
         set_duckdb_extension_directory(&conn).expect("failed to set duckdb extension directory");
 
+    // duckdb-rs stopped bundling in httpfs, so we need to load it ourselves
+    install_httpfs(&conn).expect("failed to install httpfs");
+    
     unsafe {
         GLOBAL_CONNECTION = Some(UnsafeCell::new(conn));
         GLOBAL_STATEMENT = Some(UnsafeCell::new(None));
         GLOBAL_ARROW = Some(UnsafeCell::new(None));
     }
-
-    // duckdb-rs stopped bundling in httpfs, so we need to load it ourselves
-    install_httpfs().expect("failed to install httpfs");
 
     thread::spawn(move || {
         let mut signals =
@@ -296,10 +296,10 @@ pub fn execute_explain(query: &str) -> Result<String> {
     Ok(rows.join(""))
 }
 
-pub fn install_httpfs() -> Result<()> {
+pub fn install_httpfs(conn: &Connection) -> Result<()> {
     if !check_extension_loaded("httpfs")? {
-        execute("INSTALL httpfs", [])?;
-        execute("LOAD httpfs", [])?;
+        conn.execute("INSTALL httpfs", [])?;
+        conn.execute("LOAD httpfs", [])?;
     }
     Ok(())
 }

--- a/src/duckdb/connection.rs
+++ b/src/duckdb/connection.rs
@@ -44,7 +44,7 @@ fn init_globals() {
 
     // duckdb-rs stopped bundling in httpfs, so we need to load it ourselves
     install_httpfs(&conn).expect("failed to install httpfs");
-    
+
     unsafe {
         GLOBAL_CONNECTION = Some(UnsafeCell::new(conn));
         GLOBAL_STATEMENT = Some(UnsafeCell::new(None));

--- a/src/duckdb/connection.rs
+++ b/src/duckdb/connection.rs
@@ -263,16 +263,13 @@ pub fn set_search_path(search_path: Vec<String>) -> Result<()> {
     Ok(())
 }
 
-pub fn set_duckdb_extension_directory() -> Result<usize> {
+pub fn set_duckdb_extension_directory(conn: &Connection) -> Result<usize> {
     let data_dir = unsafe {
         CStr::from_ptr(pgrx::pg_sys::DataDir)
             .to_str()
             .map_err(|e| anyhow::anyhow!("Failed to convert DataDir to &str: {}", e))?
     };
-    execute(
-        format!("SET extension_directory = '{data_dir}'").as_str(),
-        [],
-    )
+    conn.execute(format!("SET extension_directory = '{data_dir}'").as_str(), []).map_err(|err| anyhow!("{err}"))
 }
 
 pub fn execute_explain(query: &str) -> Result<String> {

--- a/src/fdw/base.rs
+++ b/src/fdw/base.rs
@@ -19,14 +19,12 @@ use anyhow::{anyhow, bail, Result};
 use duckdb::arrow::array::RecordBatch;
 use pgrx::*;
 use std::collections::HashMap;
-use std::ffi::CStr;
 use strum::IntoEnumIterator;
 use supabase_wrappers::prelude::*;
 use thiserror::Error;
 
 use super::handler::FdwHandler;
 use crate::duckdb::connection;
-use crate::fdw::base::connection::set_duckdb_extension_directory;
 use crate::schema::cell::*;
 
 #[cfg(debug_assertions)]
@@ -225,18 +223,6 @@ pub fn register_duckdb_view(
     if !user_mapping_options.is_empty() {
         connection::create_secret(DEFAULT_SECRET, user_mapping_options)?;
     }
-
-    // In CloudNativePG, the filesystem is read-only. To work around this, we force
-    // DuckDB to install its extensions in the PGDATA directory, which is writable.
-    let data_dir = unsafe {
-        CStr::from_ptr(pgrx::pg_sys::DataDir)
-            .to_str()
-            .map_err(|e| anyhow::anyhow!("Failed to convert DataDir to &str: {}", e))?
-    };
-    let _ = set_duckdb_extension_directory(data_dir);
-
-    // duckdb-rs stopped bundling in httpfs, so we need to load it ourselves
-    connection::install_httpfs()?;
 
     if !connection::view_exists(table_name, schema_name)? {
         // Initialize DuckDB view


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Moves loading `httpfs` and setting the extension directory to the start of the DuckDB connection so that the settings are available to the rest of the connection.

## Why

## How

## Tests
