### PR TITLE
fix: Doc link and extension subdirectory

### DIFF
--- a/META.json.in
+++ b/META.json.in
@@ -11,7 +11,7 @@
       "pg_analytics": {
          "abstract": "DuckDB-powered data lake analytics from Postgres",
          "file": "src/lib.rs",
-         "docfile": "doc/overview.mdx",
+         "docfile": "README.md",
          "version": "@CARGO_VERSION@"
       }
    },

--- a/src/duckdb/connection.rs
+++ b/src/duckdb/connection.rs
@@ -275,7 +275,7 @@ pub fn set_duckdb_extension_directory(conn: &Connection) -> Result<usize> {
             .map_err(|e| anyhow::anyhow!("Failed to convert DataDir to &str: {}", e))?
     };
     conn.execute(
-        format!("SET extension_directory = '{data_dir}'").as_str(),
+        format!("SET extension_directory = '{data_dir}/.duckdb/extensions'").as_str(),
         [],
     )
     .map_err(|err| anyhow!("{err}"))


### PR DESCRIPTION
Append `.duckdb/extensions` to the `extension_directory` to mimic DuckDB's default directory structure and so that the Postgres data directory doesn't fill up with directories starting with, e.g., `v1.1.1`, as it is not a Postgres version, so could be confusing.

Update the doc file in `META.json`, as the docs were dropped in 4934ae8.

[default directory structure]: https://duckdb.org/docs/extensions/overview.html#installation-location
